### PR TITLE
Fix component tests with JSX using babel-core preprocessor instead of…

### DIFF
--- a/jestSupport/scriptPreprocess.js
+++ b/jestSupport/scriptPreprocess.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var babel = require('babel-core');
+
+module.exports = {
+    process: function (src, filename) {
+        var result = babel.transform(src, {
+            filename: filename
+        });
+
+        return result.code;
+    }
+};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.9b",
   "private": true,
   "jest": {
-    "scriptPreprocessor": "./node_modules/babel-jest",
+    "scriptPreprocessor": "jestSupport/scriptPreprocess.js",
     "setupEnvScriptFile": "./node_modules/react-native/jestSupport/env.js",
     "testPathIgnorePatterns": [
       "/node_modules/"
@@ -18,6 +18,8 @@
       "es6"
     ],
     "unmockedModulePathPatterns": [
+      "react",
+      "react-addons-test-utils",
       "promise",
       "source-map",
       "key-mirror",
@@ -58,6 +60,7 @@
     "validate.js": "^0.9.0"
   },
   "devDependencies": {
+    "babel-core": "^6.4.5",
     "babel-jest": "^6.0.1",
     "docker": "^0.2.14",
     "istanbul": "gotwarlost/istanbul#source-map",


### PR DESCRIPTION
Add a temporary workaround branch: 
fix component tests with JSX using babel-core preprocessor instead of babel-jest;
fix "Failed to get mock metadata" errors for component tests by adding unmockedModulePathPatterns.