### PR TITLE
Fix failing jest tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,7 @@
       "redux-thunk",
       "fbjs"
     ],
-    "verbose": true,
-    "testPathDirs": [
-      "src/"
-    ]
+    "verbose": true
   },
   "scripts": {
     "test": "rm -rf ./node_modules/jest-cli/.haste_cache && jest ",


### PR DESCRIPTION
`node_modules` is ignored so any unit tests under that folder are not run by this change. The setting `testPathDirs` seems to limit the require targets to the specified dirs.