### PR TITLE
fix typo

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -4,7 +4,7 @@
  * This class combines all the reducers into one
  * 
  */
-'use string';
+'use strict';
 /**
  * ## Imports
  * 


### PR DESCRIPTION
change `'use string'` to `'use strict'`