### PR TITLE
Increase the Android React Native package version

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -75,7 +75,7 @@ android {
 dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
-    compile "com.facebook.react:react-native:0.17.+"
+    compile "com.facebook.react:react-native:0.20.+"
 
    // Add this line:
     compile project(':react-native-vector-icons')


### PR DESCRIPTION
Android fails to build now that the NPM react-native package version has been incremented. Updating the associated Android dependency in Gradle appears to resolve this issue.