### PR TITLE
Missing regenerator-runtime dependency?

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "redux": "3.6.0",
     "redux-thunk": "2.1.0",
     "regenerator": "0.8.46",
+    "regenerator-runtime": "0.9.6",
     "tcomb-form-native": "0.6.1",
     "undefined": "0.1.0",
     "underscore": "1.8.3",


### PR DESCRIPTION
Building the snowflake-app with `react-native start`, failed with an error about missing `regenerator-runtime/runtime.js`. Adding the `regenerator-runtime` package as a dependency solved the problem for me.

Don't know if others have run into the same problem. Feel free to just close the pull-request, if not relevant.